### PR TITLE
Remove baseURL config.

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -1,4 +1,3 @@
-baseURL = "https://fernandoabolafio.github.io/dcrbounty"
 title = "Decred Bug Bounty"
 DefaultContentLanguage = "en"
 copyright = "Decred Developers"


### PR DESCRIPTION
Removing this optional config allows running the site in any location. At the moment it can only be properly run at fernandoabolafio.github.io