### PR TITLE
Final tweaks

### DIFF
--- a/src/content/en/submit/index.md
+++ b/src/content/en/submit/index.md
@@ -20,13 +20,13 @@ Please follow a standard format when submitting vulnerabilities
 
 ##### Fix:
 
-Mailto: bugbounty {[<code>&#64;</code>]) decred.org
+Email your bug report to &#098;&#117;&#103;&#098;&#111;&#117;&#110;&#116;&#121;&#032;{[&#064;]}&#032;&#100;&#101;&#099;&#114;&#101;&#100;&#046;&#111;&#114;&#103;
 
 Always use the below PGP key to encrypt the email. Failure to do so will reduce payout amount.
 
 Any supporting evidence (screenshots, videos, etc) should be attached to the email itself. Media files should be encrypted inside a .7z, .zip or .tar.gz file with a secure password that is included in the PGP encrypted email body. Hosting on external services may lead to disqualification.
 
-`FingerPrint:D507 9E93 D0AF F567 DEF2  F6AC 6457 2029 21F7 0A78`
+`FingerPrint: D507 9E93 D0AF F567 DEF2  F6AC 6457 2029 21F7 0A78`
 
 ```
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -116,5 +116,4 @@ bWDBwFGxHlME1g==
 
 
 -----END PGP PUBLIC KEY BLOCK-----
-
 ```

--- a/src/themes/dcrbounty-theme/assets/scss/critical/banner.scss
+++ b/src/themes/dcrbounty-theme/assets/scss/critical/banner.scss
@@ -6,7 +6,7 @@
     justify-content: center;
     background: $dcr-dark-blue;
     color: $banner-text-gray;
-    padding-bottom: 40px;
+    padding-bottom: 10px;
 
     #banner-bugs {
         height: 300px;
@@ -17,8 +17,8 @@
         text-align: center;
         display: flex;
         flex-direction: column;
-        justify-content: center;
         max-width: 600px;
+        padding-top: 35px;
     }
 
     #skirt {
@@ -52,6 +52,8 @@
         font-weight: 600;
         text-decoration: none;
         cursor: pointer;
+        display: inline-block;
+        margin-bottom: 10px;
 
         &:hover {
             background: $button-hover-blue;
@@ -60,11 +62,13 @@
 
     @media (max-width: 768px) {
         #banner-text {
-            max-width: 80%
+            max-width: 80%;
+            padding-top: 0;
         }
+
         #banner-bugs {
-            height: 200px;
-            width: 200px;
+            height: 250px;
+            width: 250px;
         }
     }
 }

--- a/src/themes/dcrbounty-theme/assets/scss/critical/bottombar.scss
+++ b/src/themes/dcrbounty-theme/assets/scss/critical/bottombar.scss
@@ -1,12 +1,10 @@
 .bottom-bar {
     width: calc(100% - 40px);
-    margin-top: 10em;
     background-color: $dcr-dark-blue;
     padding: 20px 20px;
-    color: #eee;
 
     a {
-        color: #eee;
+        color: $banner-text-gray;
     }
 
     .link {

--- a/src/themes/dcrbounty-theme/assets/scss/critical/fonts.scss
+++ b/src/themes/dcrbounty-theme/assets/scss/critical/fonts.scss
@@ -141,4 +141,17 @@ section {
     a:active {
         color: #1A59F7;
     }
+
+    code {
+        border-radius   : 3px;
+        background-color: #EDEFF1;
+        color           : #37474F;
+        display         : inline-block;
+        width           : auto;
+        padding         : 5px;
+    }
+
+    pre > code {
+        padding         : 20px;
+    }
 }

--- a/src/themes/dcrbounty-theme/assets/scss/critical/main.scss
+++ b/src/themes/dcrbounty-theme/assets/scss/critical/main.scss
@@ -24,7 +24,7 @@ section {
     min-height: 120px;
     width: calc(80% - 4em);
     z-index: 1;
-    margin-bottom: 20px;
+    margin: 10px;
     & > a {
         display: block;
         position: relative;

--- a/src/themes/dcrbounty-theme/assets/scss/critical/topbar.scss
+++ b/src/themes/dcrbounty-theme/assets/scss/critical/topbar.scss
@@ -51,8 +51,7 @@
         right: -100vw;
         top: 0;
         height: 100vh;
-        overflow-y: scroll;
-        overflow-x: visible;
+        overflow: none;
         transition: right 0.3s ease,
                     box-shadow 0.3s ease;
         z-index: 999;
@@ -64,7 +63,7 @@
             margin: 0;
             padding: 3em 0 0;
             min-height: 100%;
-            width: 100%;
+            width: 100vw;
             background: white;
 
 

--- a/src/themes/dcrbounty-theme/assets/scss/critical/topbar.scss
+++ b/src/themes/dcrbounty-theme/assets/scss/critical/topbar.scss
@@ -191,7 +191,7 @@
                     
                     & > a {
                         text-decoration: none;
-                        color: white;;
+                        color: $banner-text-gray;
                         &:hover {
                             color: $dcr-alt-blue;
                         }

--- a/src/themes/dcrbounty-theme/layouts/partials/footer.html
+++ b/src/themes/dcrbounty-theme/layouts/partials/footer.html
@@ -3,7 +3,7 @@
     {{ $dcrlogo := resources.Get "img/iconDecredLightBlue.svg" }}
     <a class="link" href="https://github.com/decred">
         <img src="{{ $dcrlogo.Permalink }}" />
-        <span>Decred developers</span>
+        <span>Decred Developers</span>
     </a>
 </div>
 


### PR DESCRIPTION
- Use grey instead of white for header and footer text
- Remove 10em top padding from footer, which removes unnecessary blank space at bottom of the page.
- Improve banner scaling on mobile
- Decred style for code blocks
- As a result of styling code blocks, I had to change how the email address is obfuscated.