### PR TITLE
Add security headers and disable nginx version exposure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,6 @@ LABEL description="dcrbounty server"
 LABEL version="1.0"
 LABEL maintainer="holdstockjamie@gmail.com"
 
+COPY conf/nginx.conf /etc/nginx/conf.d/default.conf
 
 COPY --from=0 /root/public/ /usr/share/nginx/html

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,0 +1,53 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    #Disable nginx 
+    server_tokens off;
+    #Security Headers
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;  
+    add_header X-XSS-Protection "1; mode=block" always; 
+    add_header Referrer-Policy "no-referrer" always;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}
+

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -2,8 +2,9 @@ server {
     listen       80;
     server_name  localhost;
 
-    #Disable nginx 
+    #Hide Version
     server_tokens off;
+    
     #Security Headers
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;  
@@ -26,28 +27,5 @@ server {
     location = /50x.html {
         root   /usr/share/nginx/html;
     }
-
-    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
-    #
-    #location ~ \.php$ {
-    #    proxy_pass   http://127.0.0.1;
-    #}
-
-    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
-    #
-    #location ~ \.php$ {
-    #    root           html;
-    #    fastcgi_pass   127.0.0.1:9000;
-    #    fastcgi_index  index.php;
-    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
-    #    include        fastcgi_params;
-    #}
-
-    # deny access to .htaccess files, if Apache's document root
-    # concurs with nginx's one
-    #
-    #location ~ /\.ht {
-    #    deny  all;
-    #}
 }
 


### PR DESCRIPTION
Edited Dockerfile to copy over conf/nginx.conf 

New nginx.conf contains the following. 

Adds 
"server_tokens off;" which disables nginx version from being shown. 

Adds the following security headers.

add_header X-Content-Type-Options "nosniff" always;  ==> Prevents "mime" based attacks. 
add_header X-Frame-Options DENY always;   ==> Disable iframe of the website. 
add_header X-XSS-Protection "1; mode=block" always;  ==> Enable XSS protection. 
add_header Referrer-Policy "no-referrer" always; ==> Disable referrer from being shared on any request.

"always" forces these headers for all response codes.

http://nginx.org/en/docs/http/ngx_http_headers_module.html