### PR TITLE
Render contents as markdown text

### DIFF
--- a/src/themes/dcrbounty-theme/layouts/partials/news.html
+++ b/src/themes/dcrbounty-theme/layouts/partials/news.html
@@ -8,7 +8,7 @@
             <span class="checkpoint"></span>
             <span class="date">{{ dateFormat  "January 2, 2006" .date }}</span>
             <span class="title">{{ .title }}</span>
-            <p>{{ .body }}</p>
+            <div>{{ .body | markdownify }}</div>
         </li>
     {{ end }}
     </ul>

--- a/src/themes/dcrbounty-theme/layouts/partials/ranking.html
+++ b/src/themes/dcrbounty-theme/layouts/partials/ranking.html
@@ -10,7 +10,7 @@
                     <div class="person">
                         <div class="pos-name">
                             <span class="position">{{ .position }}</span>
-                            <span class="name">{{ .name }}</span>
+                            <span class="name">{{ .name | markdownify }}</span>
                         </div>
                         <a class="link" href="https://github.com/{{ .github_id }}">{{ .github_id }}</a>
                     </div>


### PR DESCRIPTION
This PR modifies the content rendering to use markdown for: 
- New & Updates (items body)
- Hall of Fame (Person name)