### PR TITLE
Remove external font-awesome resource

### DIFF
--- a/src/themes/dcrbounty-theme/layouts/partials/head.html
+++ b/src/themes/dcrbounty-theme/layouts/partials/head.html
@@ -23,8 +23,7 @@
 
     {{ $favicon := resources.Get "img/favicon.ico" }}
     <link rel="shortcut icon" type="image/png" href="{{ $favicon.Permalink }}" />
-
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
+    
 </head>
 
 <header class="top-bar">


### PR DESCRIPTION
Closes #53 

fontawesome is not used anywhere, so no need to pull it from a third party. If we do want to use it, we should host it ourselves.