### PR TITLE
Use latest hugo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 # builder image
-FROM alpine:edge
+FROM alpine:latest
 
-ARG HUGO_BASEURL
-ENV HUGO_BASEURL ${HUGO_BASEURL:-https://bounty.decred.org}
-ENV HUGO_VERSION 0.64.1
+ENV HUGO_VERSION 0.66.0
 
 LABEL description="gohugo build"
 LABEL version="1.0"
@@ -12,7 +10,7 @@ LABEL maintainer="peter@froggle.org"
 WORKDIR /tmp
 
 RUN apk update && apk upgrade
-RUN apk add --no-cache wget libc6-compat g++
+RUN apk add --no-cache bash wget libc6-compat g++
 RUN wget -q https://github.com/gohugoio/hugo/releases/download/v$HUGO_VERSION/hugo_extended_"$HUGO_VERSION"_Linux-64bit.tar.gz
 RUN tar xz -C /usr/local/bin -f hugo_extended_"$HUGO_VERSION"_Linux-64bit.tar.gz
 


### PR DESCRIPTION
- Use `latest` alpine image rather than `edge`. We don't need the bleeding edge release which may include untested or broken functionality
- Removed `HUGO_BASEURL` param which was unused