### PR TITLE
Ensure owasp table is rendered

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # builder image
 FROM alpine:latest
 
-ENV HUGO_VERSION 0.67.1
+ENV HUGO_VERSION 0.68.3
 
 LABEL description="gohugo build"
 LABEL version="1.0"

--- a/src/config.toml
+++ b/src/config.toml
@@ -3,6 +3,11 @@ DefaultContentLanguage = "en"
 copyright = "Decred Developers"
 theme = "dcrbounty-theme"
 
+[markup.goldmark.renderer]
+# This enables embedding raw HTML in markdown files.
+# Needed for attaching inline css style to images.
+  unsafe= true
+
 [params.bannerLink]
   URL = "#Submit Vulnerability"
 

--- a/src/content/en/rules/index.md
+++ b/src/content/en/rules/index.md
@@ -42,7 +42,7 @@ We ask that you respect the following rules and guidelines:
 
 We will be using the [OWASP Risk Rating Methodology](https://www.owasp.org/index.php/OWASP_Risk_Rating_Methodology) for assessing vulnerabilities and determining payout amount.
 
-<img src="img/owasp-rating.png" style="width: 80%; max-width: 448px;" />
+<img src="img/owasp-rating.png" style="width: 80%; max-width: 448px;" alt="owasp risk rating table"/>
 
 We will also take into consideration the impact on the Decred ecosystem. An RCE in dcrweb (low impact) is not the same as an RCE in dcrd or Decrediton (higher impact).
 


### PR DESCRIPTION
Since Hugo 0.60.0, raw HTML is not rendered by default. Config needs updating. 

This also updates to the latest release of hugo 0.68.3.