### PR TITLE
Remove quotes from generic font-family names

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Build
       run: docker build -t decred/dcrbounty:$(date +%s) .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # builder image
 FROM alpine:latest
 
-ENV HUGO_VERSION 0.68.3
+ENV HUGO_VERSION 0.73.0
 
 LABEL description="gohugo build"
 LABEL version="1.0"
@@ -21,7 +21,7 @@ COPY src/ /root/
 RUN hugo
 
 # Serve image (stable nginx version)
-FROM nginx:1.16
+FROM nginx:1.18
 
 LABEL description="dcrbounty server"
 LABEL version="1.0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2018-2019 The Decred developers
+Copyright (c) 2018-2020 The Decred developers
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/src/themes/dcrbounty-theme/assets/scss/critical/fonts.scss
+++ b/src/themes/dcrbounty-theme/assets/scss/critical/fonts.scss
@@ -48,13 +48,11 @@
 }
 
 html, body {
-    /* use !important to prevent issues with browser extensions that change fonts */
-    font-family: "dcrbounty", "Verdana", "sans-serif" !important;
+    font-family: "dcrbounty", "Verdana", sans-serif;
 }
 
 pre, code {
-    /* use !important to prevent issues with browser extensions that change fonts */
-    font-family: "dcrbounty-code", "Courier New", "monospace" !important;
+    font-family: "dcrbounty-code", "Courier New", monospace;
 }
 
 section {


### PR DESCRIPTION
Discovered in decred/dcrdocs#1103, generic font-family names should not have quotes: https://developer.mozilla.org/en-US/docs/Web/CSS/font-family

Also taken the opportunity to update build deps.