### PR TITLE
Add baseUrl to config.

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -1,3 +1,4 @@
+baseurl = "https://bounty.decred.org/"
 title = "Decred Bug Bounty"
 DefaultContentLanguage = "en"
 copyright = "Decred Developers"


### PR DESCRIPTION
This is required for `og:image` and `twitter:image` tags to set a proper absolute URL rather than just relative (which doesn't work)