### PR TITLE
Update scope.

### DIFF
--- a/src/content/en/news/scope-changes1.md
+++ b/src/content/en/news/scope-changes1.md
@@ -1,0 +1,12 @@
+---
+title: "Scope Changes"
+draft: false
+slug: "scope-changes"
+date: 2021-09-10
+type: "page"
+---
+
+The scope of the bug bounty program has been updated with the following changes:
+
+- [dcrdocs](https://github.com/decred/dcrdocs) is no longer in scope.
+- [dcrstakepool](https://github.com/decred/dcrstakepool) has been replaced by its successor [vspd](https://github.com/decred/vspd).

--- a/src/content/en/news/status-update15.md
+++ b/src/content/en/news/status-update15.md
@@ -10,9 +10,8 @@ We have processed a total of 195 submissions so far, with 18 of them being eligi
 
 Details of two vulnerabilities can now be made public.
 
-[Dcrdata Cross site Scripting](https://github.com/decred/dcrdata/pull/1836)
-
-[Politeia password reset email had no rate limits](https://github.com/decred/politeia/issues/1398)
+- [Dcrdata Cross site Scripting](https://github.com/decred/dcrdata/pull/1836)
+- [Politeia password reset email had no rate limits](https://github.com/decred/politeia/issues/1398)
 
 Congrats to @kazan71p and @sanket_722 who have been listed in the Hall of Fame.
 

--- a/src/content/en/news/status-update2.md
+++ b/src/content/en/news/status-update2.md
@@ -10,8 +10,8 @@ We have processed a total of 49 submissions so far, with 7 of them being
 eligible for a payout. The following vulnerabilities have been fixed and hence
 can be listed.
 
-[Politeia email notification on password change](https://github.com/decred/politeia/issues/673)  
-[Politeia cached user data needs to be cleared out on logout](https://github.com/decred/politeiagui/issues/1002)  
-[Stakepool cached user data needs to be cleared out on logout](https://github.com/decred/dcrstakepool/issues/318)  
-[Stakepool invalidate password reset token on email change](https://github.com/decred/dcrstakepool/issues/320)  
-[Stakepool password reset token leaking to github](https://github.com/decred/dcrstakepool/issues/376)  
+- [Politeia email notification on password change](https://github.com/decred/politeia/issues/673)  
+- [Politeia cached user data needs to be cleared out on logout](https://github.com/decred/politeiagui/issues/1002)  
+- [Stakepool cached user data needs to be cleared out on logout](https://github.com/decred/dcrstakepool/issues/318)  
+- [Stakepool invalidate password reset token on email change](https://github.com/decred/dcrstakepool/issues/320)  
+- [Stakepool password reset token leaking to github](https://github.com/decred/dcrstakepool/issues/376)  

--- a/src/content/en/news/status-update3.md
+++ b/src/content/en/news/status-update3.md
@@ -12,6 +12,6 @@ We have processed a total of 67 submissions so far, with 9 of them being
 eligible for a payout. The following vulnerabilities have been fixed and hence
 can be listed.
 
-[Stakepool user session not expiring on password change](https://github.com/decred/dcrstakepool/issues/328)  
-[Stakepool user define link in error page](https://github.com/decred/dcrstakepool/issues/378)  
-[Stakepool user session not expiring on logout](https://github.com/decred/dcrstakepool/issues/379)  
+- [Stakepool user session not expiring on password change](https://github.com/decred/dcrstakepool/issues/328)  
+- [Stakepool user define link in error page](https://github.com/decred/dcrstakepool/issues/378)  
+- [Stakepool user session not expiring on logout](https://github.com/decred/dcrstakepool/issues/379)  

--- a/src/content/en/news/status-update4.md
+++ b/src/content/en/news/status-update4.md
@@ -10,4 +10,4 @@ We have processed a total of 83 submissions so far, with 10 of them being
 eligible for a payout. The following vulnerability has been fixed and hence can
 be listed.
 
-[Dcrdata POST based open redirect](https://github.com/decred/dcrdata/pull/1563)
+- [Dcrdata POST based open redirect](https://github.com/decred/dcrdata/pull/1563)

--- a/src/content/en/news/status-update5.md
+++ b/src/content/en/news/status-update5.md
@@ -10,4 +10,4 @@ We have processed a total of 97 submissions so far, with 11 of them being
 eligible for a payout. The following vulnerability has been fixed and hence can
 be listed.
 
-[Politeia Secuity headers fix](https://github.com/decred/politeiagui/pull/1744)
+- [Politeia Secuity headers fix](https://github.com/decred/politeiagui/pull/1744)

--- a/src/content/en/news/status-update6.md
+++ b/src/content/en/news/status-update6.md
@@ -10,7 +10,7 @@ We have processed a total of 104 submissions so far, with 11 of them being eligi
 
 The PR linked below fixes a potential multi-day memory exhaustion attack that could lead to a node crash in dcrd 1.4.0. The network hardforked on 13/03/2020 and these older vulnerable clients have been forked off, hence this vulnerability has little to no impact on the working of the network.
 
-[dcrd memory exhaustion via unbounded knownAddresses map](https://github.com/decred/dcrd/pull/1683)
+- [dcrd memory exhaustion via unbounded knownAddresses map](https://github.com/decred/dcrd/pull/1683)
 
 All bug reporters are given the chance to be listed in the hall of fame, and we are happy to welcome Aaron Hook who discovered the issue above. Thanks for participating Aaron!
 

--- a/src/content/en/news/status-update7.md
+++ b/src/content/en/news/status-update7.md
@@ -9,4 +9,4 @@ type: "page"
 We have processed a total of 123 submissions so far, with 13 of them being eligible for a payout. The following vulnerability has been fixed and hence can
 be listed.
 
-[testnetfaucet race could drain wallet](https://github.com/decred/testnetfaucet/pull/60)
+- [testnetfaucet race could drain wallet](https://github.com/decred/testnetfaucet/pull/60)

--- a/src/content/en/scope/index.md
+++ b/src/content/en/scope/index.md
@@ -10,11 +10,10 @@ type: "section"
 |---|---|
 |[dcrweb](https://github.com/decred/dcrweb)|<https://decred.org>|
 |[politeia](https://github.com/decred/politeia) & [politeiagui](https://github.com/decred/politeiagui)|<https://proposals.decred.org>|
-|[dcrdocs](https://github.com/decred/dcrdocs)|<https://docs.decred.org>|
 |[dcrwebapi](https://github.com/decred/dcrwebapi)|<https://api.decred.org>|
 |[testnetfaucet](https://github.com/decred/testnetfaucet)|<https://faucet.decred.org>|
 |[dcrdata](https://github.com/decred/dcrdata) *(latest stable release branch only)*|<https://explorer.dcrdata.org>|
-|[dcrtime](https://github.com/decred/dcrtime)|<https://time.decred.org>|
+|[dcrtime](https://github.com/decred/dcrtime)||
 |[dcrios *](https://github.com/planetdecred/dcrios) | <https://apps.apple.com/us/app/decred-wallet/id1462247643>|
 |[dcrandroid *](https://github.com/planetdecred/dcrandroid)| <https://play.google.com/store/apps/details?id=com.decred.dcrandroid.mainnet>|
 |[cspp](https://github.com/decred/cspp/)||

--- a/src/themes/dcrbounty-theme/assets/scss/critical/news.scss
+++ b/src/themes/dcrbounty-theme/assets/scss/critical/news.scss
@@ -2,11 +2,23 @@
     list-style-type: none;
     border-left: 1px dashed black;
     padding-left: 12px;
-    li {
+
+    .news-list-item {
         margin-top: 0;
         position: relative;
         display: flex;
         flex-direction: column;
+        padding-top: 0;
+        padding-bottom: 20px;
+
+        
+        .news-list-content {
+            p {
+                line-height: normal;
+                margin-top: 8px;
+                margin-bottom: 8px;
+            }
+        }
 
         .date {
             font-size: 12px;

--- a/src/themes/dcrbounty-theme/layouts/partials/news.html
+++ b/src/themes/dcrbounty-theme/layouts/partials/news.html
@@ -4,11 +4,11 @@
     {{ $items := (where .ctx.Site.RegularPages "Section" "news") }}
     <ul class="news-list">
     {{ range first .itemsLimit $items }}
-        <li>
+        <li class="news-list-item">
             <span class="checkpoint"></span>
             <span class="date">{{ dateFormat  "January 2, 2006" .Params.date }}</span>
             <a href="{{.Permalink}}" class="title">{{ .Params.title }}</a>
-            <div>{{ .Content }}</div>
+            <div class="news-list-content">{{ .Content }}</div>
         </li>
     {{ end }}
     </ul>


### PR DESCRIPTION
- Remove dcrdocs from scope.
- Remove link to time.decred.org because it was just redirecting to the github repo.
- Change news item css to reduce paragraph spacing, and to use bulleted lists.
- Add news item which outlines recent scope changes.

### Before

![Screenshot from 2021-09-10 14-39-15](https://user-images.githubusercontent.com/6762864/132862332-5c0f1782-7eb7-41b8-840e-e5bd1a30b4a2.png)

### After

![Screenshot from 2021-09-10 14-39-05](https://user-images.githubusercontent.com/6762864/132862337-b07c704c-d325-4074-8dbc-3e0da5b81ebc.png)
