### PR TITLE
Update Hall of Fame.

### DIFF
--- a/src/data/ranking.yml
+++ b/src/data/ranking.yml
@@ -1,45 +1,91 @@
-# - name: Abubakar Suleiman
-#   github_id: macsleven
-#   twitter_id: macsleven
-#   points: 1000
+# Hall of Fame
+#
+# Points are awarded according to *actual* reward payment sent, ie. the penalty
+# for missing PGP is applied to points just as it is to payments.
+#
+# Each listed participant can have either a GitHub or Twitter link, not both.
+#
+# "reports" are formatted as "report number: reward amount".
+
+- name: Anonymous
+  reports:
+    29: 72
+    30: 150
+    37: 100
+    47: 135
+    51: 150
+    52: 50
+    80: 90
+    91: 135
+
+- name: Ramesh Jeyaraman
+  reports:
+    11: 72
 
 - name: Aaron Hook
   twitter_id: therealahook
-  points: 3000
+  reports:
+    32: 3000
 
 - name: Javed Khan
   twitter_id: tuxcanfly
-  points: 2500
+  reports:
+    132: 2500
 
 - name: Alex Bastrakov
   twitter_id: kazan71p
-  points: 630
+  reports:
+    191: 630
 
 - name: Sheikh Rishad
   twitter_id: sheikhrishad0
-  points: 450
+  reports:
+    196: 450
 
 - name: Shankar R
   github_id: trapp3rhat
-  points: 450
+  reports:
+    215: 450
+    216: 0 # Reports 215 and 216 were combined into one payment.
 
 - name: Al1ex
   github_id: Al1ex
-  points: 300
+  points: 
+  reports:
+    193: 270
 
 - name: Caio Lüders
   twitter_id: caioluders
-  points: 250
+  points: 
+  reports:
+    109: 250
 
 - name: Abiral Shrestha
   twitter_id: proabiral
-  points: 90
+  points: 
+  reports:
+    153: 90
 
 - name: Sanket Salavi
   twitter_id: sanket_722
-  points: 90
+  points: 
+  reports:
+    164: 270
 
 - name:  Aditi Singh
   twitter_id: aditi_singghh
-  points: 90
-  
+  points: 
+  reports:
+    224: 90
+
+- name: Burhanuddin Sabunwala
+  twitter_id: B19R8A14
+  points: 
+  reports:
+    242: 100
+
+- name: David McPavel
+  github_id: itsunixiknowthis
+  points: 
+  reports:
+    116: 3000

--- a/src/themes/dcrbounty-theme/assets/scss/critical/ranking.scss
+++ b/src/themes/dcrbounty-theme/assets/scss/critical/ranking.scss
@@ -48,8 +48,3 @@
     }
 
 }
-
-.no-ranking-items-message {
-    height: 100px;
-    color: $dcr-blue;
-}

--- a/src/themes/dcrbounty-theme/layouts/partials/ranking.html
+++ b/src/themes/dcrbounty-theme/layouts/partials/ranking.html
@@ -1,27 +1,35 @@
 <section>
     <a name="hall_of_fame"></a>
+    
     <h2>Hall of Fame</h2>
-    {{ $contributors := .Site.Data.ranking}}
-    {{ if ne $contributors nil }}
-        <ul class="ranking-list">
-            {{ range $idx, $contributor := (sort $contributors "points" "desc") }}
-                <li>
-                    <div class="person">
-                        <div class="pos-name">
-                            <span class="position">{{ add $idx 1 }}</span>
-                            <span class="name">{{ $contributor.name | markdownify }}</span>
-                        </div>
-                        {{ if .github_id }} <a class="link" href="https://github.com/{{ $contributor.github_id }}"  >{{ $contributor.github_id  }}</a>{{ end }}
-                        {{ if .twitter_id }}<a class="link" href="https://twitter.com/{{ $contributor.twitter_id }}">{{ $contributor.twitter_id }}</a>{{ end }}
-                    </div>
-                    <span class="points">{{ $contributor.points }} pts</span>
-                </li>
+
+    <!-- To make the contributor list sortable, create a new slice which includes total reward payments. -->
+    {{ $sortable := slice }}
+    {{ range $idx, $contributor := .Site.Data.ranking }}
+    
+        {{ $totalReward := 0}}
+            {{ range $idx, $reward := $contributor.reports }}
+                {{ $totalReward = add $totalReward $reward }}
             {{ end }}
-            </ul>
-    {{ else }}
-         <div>
-            <a href="{{ .Site.Params.bannerLink.URL }}" class="no-ranking-items-message">Be the first to report a bug and get placed here</a>
-         </div>
+        {{ $contributor = merge $contributor (dict "totalReward" $totalReward) }}
+
+        {{ $sortable = append $contributor $sortable }}
     {{ end }}
+    
+    <ul class="ranking-list">
+        {{ range $idx, $contributor := (sort $sortable "totalReward" "desc") }}
+            <li>
+                <div class="person">
+                    <div class="pos-name">
+                        <span class="position">{{ add $idx 1 }}</span>
+                        <span class="name">{{ $contributor.name }}</span>
+                    </div>
+                    {{ if .github_id }} <a class="link" href="https://github.com/{{ $contributor.github_id }}"  >{{ $contributor.github_id  }}</a>{{ end }}
+                    {{ if .twitter_id }}<a class="link" href="https://twitter.com/{{ $contributor.twitter_id }}">{{ $contributor.twitter_id }}</a>{{ end }}
+                </div>
+                <span class="points">{{$contributor.totalReward}} pts</span>
+            </li>
+        {{ end }}
+    </ul>
     
 </section>


### PR DESCRIPTION
- Add report numbers to track reports/rewards individually, rather than just total reward.
- Add reports from anonymous contributors.
- Add Ramesh Jeyaraman and David McPavel (historic). Both provided HoF details but were never added to the site.
- Add Burhanuddin Sabunwala (recent).
- Deduct PGP penalty from Al1ex (300 => 270).
- Fix incorrect points for Sanket Salavi (90 => 270).
- Remove handling for empty HoF.

![Screenshot from 2022-11-03 14-46-55](https://user-images.githubusercontent.com/6762864/199753064-d6f29c98-6ce8-42af-9bf1-70171cffda0b.png)
