### PR TITLE
Use hugo 0.110.0.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - name: Build
       run: docker build -t decred/dcrbounty:$(date +%s) .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 
 ARG HUGO_BASEURL
 ENV HUGO_BASEURL ${HUGO_BASEURL:-https://bounty.decred.org}
-ENV HUGO_VERSION 0.104.3
+ENV HUGO_VERSION 0.110.0
 
 LABEL description="gohugo build"
 LABEL version="1.0"
@@ -13,8 +13,8 @@ WORKDIR /tmp
 
 RUN apk update && apk upgrade
 RUN apk add --no-cache bash wget libc6-compat g++
-RUN wget -q https://github.com/gohugoio/hugo/releases/download/v$HUGO_VERSION/hugo_extended_"$HUGO_VERSION"_Linux-64bit.tar.gz
-RUN tar xz -C /usr/local/bin -f hugo_extended_"$HUGO_VERSION"_Linux-64bit.tar.gz
+RUN wget -q https://github.com/gohugoio/hugo/releases/download/v$HUGO_VERSION/hugo_extended_"$HUGO_VERSION"_linux-amd64.tar.gz
+RUN tar xz -C /usr/local/bin -f hugo_extended_"$HUGO_VERSION"_linux-amd64.tar.gz
 
 WORKDIR /root
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2018-2022 The Decred developers
+Copyright (c) 2018-2023 The Decred developers
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/bin/watch.sh
+++ b/bin/watch.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # Remove old hugo output before building
 rm -rf src/public src/resources
 


### PR DESCRIPTION
Nothing much included in recent versions, mostly bug-fixes and build/CI improvements. The binary name has changed so thats updated in our Dockerfile.