### PR TITLE
build: Docker cleanup/update.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,12 @@
-.git/
-.github/
+.gitignore
+.git
+.github
+LICENSE
+README.md
+
+bin/build.sh
+bin/watch.sh
+src/public
+src/resources
+src/.hugo_build.lock
+email-templates

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 dist/
 src/resources
 src/public
-.hugo_build.lock
+src/.hugo_build.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# builder image
+# Build image
 FROM alpine:latest
 
 ARG HUGO_BASEURL
@@ -23,7 +23,7 @@ COPY ./ /root/
 RUN bin/build-hugo.sh
 
 # Serve image (stable nginx version)
-FROM nginx:1.22
+FROM nginx:1.22-alpine
 
 LABEL description="dcrbounty server"
 LABEL version="1.0"

--- a/bin/build-hugo.sh
+++ b/bin/build-hugo.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # Remove old hugo output before building
 rm -rf src/public src/resources
 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -9,7 +9,6 @@ echo "  Building dcrbounty docker image  "
 echo "==================================="
 echo ""
 
-
 IMAGE_NAME=decred/dcrbounty
 
 if [ "$1" != "" ]; then

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -2,16 +2,17 @@ server {
     listen       80;
     server_name  localhost;
 
-    #Hide Version
+    charset utf-8;
+    
+    # Hide Version
     server_tokens off;
     
-    #Security Headers
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "DENY" always;  
-    add_header X-XSS-Protection "1; mode=block" always; 
-    add_header Referrer-Policy "no-referrer" always;
+    # Security Headers
+    add_header X-Content-Type-Options "nosniff"       always;
+    add_header X-Frame-Options        "DENY"          always;
+    add_header X-XSS-Protection       "1; mode=block" always;
+    add_header Referrer-Policy        "no-referrer"   always;
 
-    charset utf-8;
     #access_log  /var/log/nginx/host.access.log  main;
 
     location / {
@@ -36,6 +37,6 @@ server {
     gzip_comp_level 6;
     gzip_buffers 16 8k;
     gzip_http_version 1.1;
-    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss image/svg+xml text/javascript;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/rss+xml image/svg+xml text/javascript;
 }
 


### PR DESCRIPTION
- Use Alpine version of nginx image (23MB instead of 142MB)
- Fix MIME type for rss feeds.
- Clean up .gitignore and .dockerignore.
- Ensure scripts fail on error.