### PR TITLE
Remove 404s from Hall of Fame.

### DIFF
--- a/src/data/hall_of_fame.yml
+++ b/src/data/hall_of_fame.yml
@@ -43,7 +43,6 @@
     196: 450
 
 - name: Shankar R
-  github_id: trapp3rhat
   reports:
     215: 450
     216: 0 # Reports 215 and 216 were combined into one payment.
@@ -64,7 +63,6 @@
     153: 90
 
 - name: Sanket Salavi
-  twitter_id: sanket_722
   reports:
     164: 270
 


### PR DESCRIPTION
- trapp3rhat account no longer exists on github.
- sanket_722 account no longer exists on twitter.