### PR TITLE
Fix topbar menu links.

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -28,24 +28,19 @@ copyright = "Decred Developers"
 [[menu.main]]
 name = "Hall of Fame"
 url = "#hall-of-fame"
-weight = 1
 
 [[menu.main]]
 name = "News and Updates"
 url = "#news"
-weight = 1
 
 [[menu.main]]
 name = "Rules"
 url = "#rules"
-weight = 1
 
 [[menu.main]]
 name = "Scope"
 url = "#scope"
-weight = 1
 
 [[menu.main]]
 name = "Submit Vulnerability"
 url = "#submit-vulnerability"
-weight = 1

--- a/src/layouts/partials/content.html
+++ b/src/layouts/partials/content.html
@@ -2,7 +2,7 @@
 {{ range $items }}
 {{ if eq .Type "section" }}
 <section>
-    <a name="{{ .Title }}"></a>
+    <a name="{{ .Title | urlize }}"></a>
     <h2>{{ .Title }}</h2> 
     <div class="content">
         {{ .Content }}


### PR DESCRIPTION
Using `urlize` fixes the topbar links by replacing whitespace with hyphens and ensuring all characters are lower case.

Previously three of the links did not work.

Also removing weight from the menu items because they are ineffective when all of the weights are the same.