### PR TITLE
Update to nginx 1.30.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY ./ /root/
 RUN bin/build-hugo.sh
 
 # Serve image (stable nginx version)
-FROM nginx:1.28-alpine
+FROM nginx:1.30-alpine
 
 LABEL description="dcrbounty server"
 LABEL version="1.0"


### PR DESCRIPTION
This pulls in fixes for some recent high severity security advisories.