### PR TITLE
Link to new site.

### DIFF
--- a/src/assets/scss/critical/banner.scss
+++ b/src/assets/scss/critical/banner.scss
@@ -43,23 +43,6 @@
         line-height: 20px;
     }
 
-    .button {
-        font-size: 14px;
-        border-radius: 4px;
-        padding: 12px 20px 13px;
-        background: $dcr-blue;
-        color: white;
-        font-weight: 600;
-        text-decoration: none;
-        cursor: pointer;
-        display: inline-block;
-        margin-bottom: 10px;
-
-        &:hover {
-            background: $button-hover-blue;
-        }
-    }
-
     @media (max-width: 768px) {
         #banner-text {
             max-width: 80%;

--- a/src/assets/scss/critical/main.scss
+++ b/src/assets/scss/critical/main.scss
@@ -57,6 +57,23 @@ section {
     text-align: left;
 }
 
+.button {
+    font-size: 14px;
+    border-radius: 4px;
+    padding: 12px 20px 13px;
+    background: $dcr-blue !important;
+    color: white !important;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    display: inline-block;
+    margin-bottom: 10px;
+
+    &:hover {
+        background: $button-hover-blue;
+    }
+}
+
 @media only screen and (max-width: 768px) {
     body {
         margin-top: 0;

--- a/src/content/news/status-update22.md
+++ b/src/content/news/status-update22.md
@@ -1,0 +1,16 @@
+---
+title: "Bounty Program Resumes"
+draft: false
+date: 2026-07-14
+type: "page"
+---
+
+Following the [hiatus announcement in May](/2026/05/bounty-program-hiatus/), we have used the downtime to implement a spam protection measure and to refine and tighten some of the program scope and rules.
+
+That work is now complete and the Decred Bug Bounty program is open for submissions once again.
+
+To submit a report, bug reporters must now make a $5 USD deposit in DCR.
+The deposit will be refunded if the report is accepted as a valid security vulnerability.
+Deposits may also be refunded for reports that are rejected, provided the submission was made in good faith and complied with all program rules and requirements.
+
+Thank you for your patience during the hiatus, and look forward to receiving your reports once again.

--- a/src/content/submit/index.md
+++ b/src/content/submit/index.md
@@ -4,18 +4,24 @@ draft: false
 type: "section"
 ---
 
+## Submit Vulnerability
+
 Please follow a standard format when submitting vulnerabilities.
 
-##### Title:
+> ##### Title
+>
+> ##### Affected website or repository
+>
+> ##### Vulnerability Type
+>
+> ##### Details
+>
+> ##### Impact of Vulnerability
+>
+> ##### Reproduction or POC details
+>
+> ##### Fix
 
-##### Affected website or repository: 
-
-##### Vulnerability Type: 
-
-##### Details: 
-
-##### Impact of Vulnerability:
-
-##### Reproduction or POC details:
-
-##### Fix:
+<div style="text-align: center;">
+    <a href="https://bug-report.decred.org/" class="button">Submit Vulnerability</a>
+</div>


### PR DESCRIPTION
Proposal has passed and https://bug-report.decred.org has been flipped to mainnet. Ready to go.